### PR TITLE
Add ETag-based versioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3
 
 # install requirements
 ADD requirements*.txt setup.cfg ./

--- a/assets/resource.py
+++ b/assets/resource.py
@@ -36,7 +36,7 @@ class HTTPResource:
         versions = [{'version': v} for v in versions]
 
         # if version is specified get only newer versions
-        if version:
+        if version and version in versions:
             current_version = version
             new_versions = versions[versions.index(current_version):]
             new_versions.pop(0)
@@ -129,5 +129,6 @@ class HTTPResource:
             response = {}
 
         return json.dumps(response)
+
 
 print(HTTPResource().run(os.path.basename(__file__), sys.stdin.read(), sys.argv[1:]))


### PR DESCRIPTION
This PR adds [ETag](https://en.wikipedia.org/wiki/HTTP_ETag) based versioning, based a bit on the request for the functionality made here: https://github.com/concourse/archive-resource/issues/4

This works differently from the regex/index based versioning. If the `source` block contains the `etag` property, the resource will retrieve the `index`'s ETag header and treat that as a version string. If the version matches the existing ETag, an empty version set is returned. Otherwise, the current ETag value is returned as the next available version.

Example resource configuration:

```
- name: fetch-project-data
  type: http-resource
  source:
    uri: https://team-api.18f.gov/public/api/projects/
    filename: projects.json
    index: https://team-api.18f.gov/public/api/projects/
    etag: true
```

If you see value in combining multiple types of version checking into a single `http-resource`, I'd be happy to implement a body checksum method.

We are using this in our pipelines here: https://github.com/18F/concourse-compliance-testing/tree/master/pipelines.
